### PR TITLE
Implemented missing features to parse lpc11xx SVD

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,7 @@ fn write_register(register: &Register) {
 fn write_field(field: &Field) {
     let lsb = field.bitOffset.unwrap();
     let width = field.bitWidth.unwrap();
+    if field.name == "RESERVED" { return }
 
     print!("         {}", lsb);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,7 @@ deriving_fromxml! {
         description:Option<String>,
         bitOffset:Option<uint>,
         bitWidth:Option<uint>,
+        bitRange:Option<String>,
         access:Option<String>,
         enumeratedValues: Vec<EnumeratedValue>,
     }
@@ -181,9 +182,17 @@ fn write_register(register: &Register) {
 }
 
 fn write_field(field: &Field) {
-    let lsb = field.bitOffset.unwrap();
-    let width = field.bitWidth.unwrap();
     if field.name == "RESERVED" { return }
+
+    let (lsb, width) = if let Some(ref br) = field.bitRange {
+        let split: Vec<&str> = br.as_slice().split(':').collect();
+        assert_eq!(split.len(), 2);
+        let end: uint = split[0].slice_from(1).parse().unwrap();
+        let start: uint = split[1].slice_to(split[1].len()-1).parse().unwrap();
+        (start, end-start+1)
+    } else {
+        (field.bitOffset.unwrap(), field.bitWidth.unwrap())
+    };
 
     print!("         {}", lsb);
 


### PR DESCRIPTION
This PR adds support for bitRange tag in field description and ignores any fields named `RESERVED`.
